### PR TITLE
Add support for horizontal split

### DIFF
--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -27,6 +27,8 @@ local M = {
       mode = "nested",
       width = 35,
     },
+    --- Can be either `vertical` or `horizontal`
+    layout = "vertical",
   },
 
   icons = {

--- a/lua/hunk/ui/layout.lua
+++ b/lua/hunk/ui/layout.lua
@@ -12,21 +12,37 @@ local function create_vertical_split()
   return winid
 end
 
-local function resize_tree(tree, left, right, size)
+local function create_horizontal_split()
+  vim.api.nvim_command("split")
+  local winid = vim.api.nvim_get_current_win()
+  return winid
+end
+
+local function resize_tree(tree, left, right, size, layout)
   local total_width = vim.api.nvim_get_option_value("columns", {})
   local remaining_width = total_width - size
   local equal_width = math.floor(remaining_width / 2)
 
   vim.api.nvim_win_set_width(tree, size)
-  vim.api.nvim_win_set_width(left, equal_width)
-  vim.api.nvim_win_set_width(right, equal_width)
+
+  if layout == "vertical" then
+    vim.api.nvim_win_set_width(left, equal_width)
+    vim.api.nvim_win_set_width(right, equal_width)
+  end
 end
 
 function M.create_layout()
   local tree_window = vim.api.nvim_get_current_win()
 
   local left_diff = create_vertical_split()
-  local right_diff = create_vertical_split()
+  local right_diff
+  if config.ui.layout == "vertical" then
+    right_diff = create_vertical_split()
+  elseif config.ui.layout == "horizontal" then
+    right_diff = create_horizontal_split()
+  else
+    error("Unknown value '" .. config.ui.layout .. "' for config entry `ui.layout`")
+  end
 
   highlights.set_win_hl(left_diff, {
     "DiffAdd:HunkDiffAddAsDelete",
@@ -42,7 +58,7 @@ function M.create_layout()
     "HunkSignDeselected:Green",
   })
 
-  resize_tree(tree_window, left_diff, right_diff, config.ui.tree.width)
+  resize_tree(tree_window, left_diff, right_diff, config.ui.tree.width, config.ui.layout)
 
   vim.api.nvim_set_current_win(tree_window)
 


### PR DESCRIPTION
Introduces new config value `ui.layout that takes one of two values:
|| |
|-----|-----|
|`vertical`   | old default behaviour (default) |
| `horizontal` | uses a horizontal split for diff views |

This can make the changes much more readable when running your terminal in a narrower window.
![image](https://github.com/user-attachments/assets/e7a86236-510c-4e41-b2e9-1d44c0506c77)