### PR TITLE
ref!: new keybinds api

### DIFF
--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -1,23 +1,35 @@
 local M = {
   keys = {
     global = {
-      quit = { "q" },
-      accept = { "<leader><Cr>" },
-      focus_tree = { "<leader>e" },
+      n = {
+        ["q"] = "<Plug>(hunk.global.quit)",
+        ["<leader><cr>"] = { "<Plug>(hunk.global.accept)", { desc = "Accept" } },
+        ["<leader>e"] = { "<Plug>(hunk.global.focus_tree)", { desc = "Focus Tree" } },
+      },
     },
 
     tree = {
-      expand_node = { "l", "<Right>" },
-      collapse_node = { "h", "<Left>" },
+      n = {
+        ["l"] = "<Plug>(hunk.tree.expand_node)",
+        ["<right>"] = "<Plug>(hunk.tree.expand_node)",
 
-      open_file = { "<Cr>" },
+        ["h"] = "<Plug>(hunk.tree.collapse_node)",
+        ["<left>"] = "<Plug>(hunk.tree.collapse_node)",
 
-      toggle_file = { "a" },
+        ["<cr>"] = "<Plug>(hunk.tree.open_file)",
+
+        ["a"] = "<Plug>(hunk.tree.toggle_file)",
+      },
     },
 
     diff = {
-      toggle_line = { "a" },
-      toggle_hunk = { "A" },
+      n = {
+        ["a"] = "<Plug>(hunk.diff.toggle_line)",
+        ["A"] = "<Plug>(hunk.diff.toggle_hunk)",
+      },
+      v = {
+        ["a"] = { "<Plug>(hunk.diff.toggle_visual_lines)", { desc = "Toggle Visual Lines", nowait = true } },
+      },
     },
   },
 

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -69,30 +69,20 @@ local function toggle_hunk(change, side, line)
 end
 
 local function set_global_bindings(layout, buf)
-  for _, chord in ipairs(utils.into_table(config.keys.global.accept)) do
-    vim.keymap.set("n", chord, function()
-      api.changeset.write_changeset(CONTEXT.changeset, CONTEXT.output or CONTEXT.right)
-      vim.cmd("qa")
-    end, {
-      buffer = buf,
-    })
-  end
+  vim.keymap.set("n", "<Plug>(hunk.global.accept)", function()
+    api.changeset.write_changeset(CONTEXT.changeset, CONTEXT.output or CONTEXT.right)
+    vim.cmd("qa")
+  end, { buffer = buf })
 
-  for _, chord in ipairs(utils.into_table(config.keys.global.quit)) do
-    vim.keymap.set("n", chord, function()
-      vim.cmd("qa")
-    end, {
-      buffer = buf,
-    })
-  end
+  vim.keymap.set("n", "<Plug>(hunk.global.quit)", function()
+    vim.cmd("qa")
+  end, { buffer = buf })
 
-  for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do
-    vim.keymap.set("n", chord, function()
-      vim.api.nvim_set_current_win(layout.tree)
-    end, {
-      buffer = buf,
-    })
-  end
+  vim.keymap.set("n", "<Plug>(hunk.global.focus_tree)", function()
+    vim.api.nvim_set_current_win(layout.tree)
+  end, { buffer = buf })
+
+  utils.set_keys(config.keys.global, { tree = layout.tree }, buf)
 end
 
 local function open_file(layout, tree, change)

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -222,17 +222,14 @@ function M.create(opts)
     apply_signs(tree, buf)
   end
 
-  for _, chord in ipairs(utils.into_table(config.keys.tree.open_file)) do
-    vim.keymap.set("n", chord, function()
-      local node = tree:get_node()
-      if node.type == "file" then
-        opts.on_open(node.change)
-      end
-    end, { buffer = buf })
-  end
+  vim.keymap.set("n", "<Plug>(hunk.tree.open_file)", function()
+    local node = tree:get_node()
+    if node.type == "file" then
+      opts.on_open(node.change)
+    end
+  end, { buffer = buf, desc = "Open File" })
 
-  for _, chord in ipairs(utils.into_table(config.keys.tree.expand_node)) do
-    vim.keymap.set("n", chord, function()
+  vim.keymap.set("n", "<Plug>(hunk.tree.expand_node)", function()
       local node = tree:get_node()
       if node.type == "file" then
         opts.on_preview(node.change)
@@ -241,27 +238,29 @@ function M.create(opts)
         node:expand()
         Component.render()
       end
-    end, { buffer = buf })
-  end
+    end, { buffer = buf, desc = "Expand Folder" })
 
-  for _, chord in ipairs(utils.into_table(config.keys.tree.collapse_node)) do
-    vim.keymap.set("n", chord, function()
+  vim.keymap.set("n", "<Plug>(hunk.tree.collapse_node)", function()
       local node = tree:get_node()
       if node.type == "dir" and node:is_expanded() then
         node:collapse()
         Component.render()
       end
-    end, { buffer = buf })
-  end
+    end, { buffer = buf, desc = "Collapse Folder" })
 
-  for _, chord in ipairs(utils.into_table(config.keys.tree.toggle_file)) do
-    vim.keymap.set("n", chord, function()
+  vim.keymap.set("n", "<Plug>(hunk.tree.toggle_file)", function()
       local node = tree:get_node()
       if node.type == "file" then
         opts.on_toggle(node.change)
       end
-    end, { buffer = buf })
-  end
+    end, { buffer = buf, desc = "Toggle File" })
+
+  local context = {
+    opts = opts,
+    tree = tree,
+  }
+
+  utils.set_keys(config.keys.tree, context, buf)
 
   local file_tree
   if config.ui.tree.mode == "nested" then

--- a/lua/hunk/utils.lua
+++ b/lua/hunk/utils.lua
@@ -90,4 +90,33 @@ function M.any_lines_selected(change)
   return false
 end
 
+---Set keys from a table of [lhs] = rhs
+---@param table table<string, table<string, string|function>>
+---@param context table? an optional context table
+---@param buf number? optional buffer
+function M.set_keys(table, context, buf)
+  for mode, binds in pairs(table) do
+    for lhs, rhs in pairs(binds) do
+      if not rhs then
+        goto continue
+      end
+
+      local opts = { buffer = buf }
+      if type(rhs) == "table" then
+        opts = vim.tbl_extend("keep", opts, rhs[2])
+        rhs = rhs[1]
+      end
+
+      if type(rhs) == "function" then
+        vim.keymap.set(mode, lhs, function()
+          rhs(context)
+        end, opts)
+      else
+        vim.keymap.set(mode, lhs, rhs, opts)
+      end
+      ::continue::
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
_Sorry I didn't open an issue, I figured this is something that I wanted to use, I'll just use a fork if you don't want want it in main._

---

~~Adds a config option: `keys.tree.skip_folders` which, when true will remap `j`/`k` so that they skip over folders in the file tree. `gj` and `gk` can still be used to move over folders.~~

~~I find this improves the experience a lot when there are multiple changes in files that may be nested deeply in folders.~~

Now this PR has become a keybinds API rewrite to enable users to bind more complex keys like the usecase described above.

This is a breaking change, totally understand if you wanted to do this is a way that wasn't breaking.. it just would have made for awkward config to add something on top.

Also fixes a bug with the visual keybind.