### PR TITLE
Make the tree window fixed-width

### DIFF
--- a/lua/hunk/ui/layout.lua
+++ b/lua/hunk/ui/layout.lua
@@ -59,6 +59,7 @@ function M.create_layout()
   })
 
   resize_tree(tree_window, left_diff, right_diff, config.ui.tree.width, config.ui.layout)
+  vim.api.nvim_set_option_value("winfixwidth", true, { win = tree_window })
 
   vim.api.nvim_set_current_win(tree_window)
 


### PR DESCRIPTION
Current the tree window is subject to resizes. I suggest that a better default behavior is to set `winfixedwidth` on the tree window, so that operations like `C-W=` affect only the diff windows.