### PR TITLE
docs: add example hook usages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,89 @@ hunk.setup({
 })
 ```
 
+### Using Hooks
+
+Hooks can be used to bind keys with "complex" logic, or to set buffer/window local options on the
+three or diff splits.
+
+<details>
+  <summary>Skipping Folders in the File Tree</summary>
+
+These bindings allow `j`/`k` to skip over folders in the file tree (b/c they're generally not
+relevant). You can still access folders with `gj`/`gk`.
+
+```lua
+-- track all the lines of leaf nodes so we don't have to recompute them on each key press
+local jumpable_lines
+local function set_jumpabe_lines(context)
+  jumpable_lines = {}
+  local i = 1
+  local n, _, _ = context.tree:get_node(i)
+  while n do
+    if not n:has_children() then
+      table.insert(jumpable_lines, i)
+    end
+    i = i + 1
+    n, _, _ = context.tree:get_node(i)
+  end
+end
+require("hunk").setup({
+  hooks = {
+    on_tree_mount = function(context)
+      vim.keymap.set("n", "j", function()
+        -- unfortunately we have to recompute every time because folding ruins these computed values
+        set_jumpabe_lines(context)
+        local row = vim.api.nvim_win_get_cursor(0)[1]
+        if row < jumpable_lines[1] then
+          vim.api.nvim_win_set_cursor(0, { jumpable_lines[1], 0 })
+          return
+        end
+        for idx = #jumpable_lines, 1, -1 do
+          if jumpable_lines[idx] <= row then
+            if jumpable_lines[idx + 1] then
+              vim.api.nvim_win_set_cursor(0, { jumpable_lines[idx + 1], 0 })
+            end
+            return
+          end
+        end
+      end, { buffer = context.buf })
+
+      vim.keymap.set("n", "k", function()
+        set_jumpabe_lines(context)
+        local row = vim.api.nvim_win_get_cursor(0)[1]
+        if row > jumpable_lines[#jumpable_lines] then
+          vim.api.nvim_win_set_cursor(0, { jumpable_lines[#jumpable_lines], 0 })
+          return
+        end
+        for idx, node_row in ipairs(jumpable_lines) do
+          if node_row >= row then
+            if jumpable_lines[idx - 1] then
+              vim.api.nvim_win_set_cursor(0, { jumpable_lines[idx - 1], 0 })
+            end
+            return
+          end
+        end
+      end, { buffer = context.buf })
+    end,
+  },
+})
+```
+</details>
+
+<details>
+  <summary>Set `nospell` in File Tree</summary>
+
+```lua
+require("hunk").setup({
+  hooks = {
+    on_tree_mount = function(context)
+      vim.api.nvim_set_option_value("spell", false, { win = context.win })
+    end,
+  }
+})
+```
+</details>
+
 ## Using with Jujutsu
 
 [Jujutsu](https://github.com/martinvonz/jj) is an alternative VCS that has a focus on working with individual commits


### PR DESCRIPTION
Two new examples for the README:

- how to setup keybinds that skip folders in the file tree
- how to set `nospell` in the file tree window