### PR TITLE
feat: auto-setup with lazy-loading

### DIFF
--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -134,7 +134,18 @@ local function open_file(layout, tree, change)
   return left_file, right_file
 end
 
+local initialised = false
+
+local function init()
+  initialised = true
+  api.signs.define_signs()
+  api.highlights.define_highlights()
+end
+
 function M.start(left, right, output)
+  if not initialised then
+    init()
+  end
   local changeset = api.changeset.load_changeset(left, right)
   local layout = ui.layout.create_layout()
 
@@ -175,20 +186,6 @@ end
 function M.setup(opts)
   opts = opts or {}
   config.update_config(opts)
-
-  api.signs.define_signs()
-  api.highlights.define_highlights()
-
-  vim.api.nvim_create_user_command("DiffEditor", function(params)
-    local args = params.fargs
-    if #args < 2 then
-      vim.notify("Error: DiffEditor expects three arguments (left, right[, output])", vim.log.levels.ERROR)
-      return
-    end
-    M.start(args[1], args[2], args[3] or args[2])
-  end, {
-    nargs = "*",
-  })
 end
 
 return M

--- a/plugin/hunk.lua
+++ b/plugin/hunk.lua
@@ -1,0 +1,15 @@
+if vim.g.loaded_hunk_nvim then
+    return
+end
+vim.g.loaded_hunk_nvim = true
+
+vim.api.nvim_create_user_command("DiffEditor", function(params)
+  local args = params.fargs
+  if #args < 2 then
+    vim.notify("Error: DiffEditor expects three arguments (left, right[, output])", vim.log.levels.ERROR)
+    return
+  end
+  require("hunk").start(args[1], args[2], args[3] or args[2])
+end, {
+  nargs = "*",
+})

--- a/plugin/hunk.vim
+++ b/plugin/hunk.vim
@@ -1,4 +1,0 @@
-if exists("g:loaded_hunk_nvim")
-    finish
-endif
-let g:loaded_hunk_nvim = 1


### PR DESCRIPTION
Hey :wave: 

I'd love to use this plugin, but I don't want to have to call a `setup` function to use it if I'm happy with the defaults.
This PR proposes to separate configuration from initialisation, automatically creating the `DiffEditor` command (initialising lazily upon the first invocation).

See also: https://github.com/nvim-neorocks/nvim-best-practices?tab=readme-ov-file#zap-initialization