### PR TITLE
fix(README): update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ the `right` directory if no output is provided) to match your selection.
 ```lua
 {
   "julienvincent/hunk.nvim",
+  dependencies = {
+    "MunifTanjim/nui.nvim"
+  },
   cmd = { "DiffEditor" },
   config = function()
     require("hunk").setup()


### PR DESCRIPTION
This commit updates the `lazy.nvim` install spec to explicitly list `nui.nvim` as a dependency.