### PR TITLE
Refactor signs to separate left/right selection states

### DIFF
--- a/lua/hunk/api/signs.lua
+++ b/lua/hunk/api/signs.lua
@@ -2,12 +2,20 @@ local config = require("hunk.config")
 
 local M = {
   signs = {
-    selected = {
-      name = "HunkLineSelected",
+    left_selected = {
+      name = "HunkLineLeftSelected",
       hl = "HunkSignSelected",
     },
-    deselected = {
-      name = "HunkLineDeselected",
+    left_deselected = {
+      name = "HunkLineLeftDeselected",
+      hl = "HunkSignDeselected",
+    },
+    right_selected = {
+      name = "HunkLineRightSelected",
+      hl = "HunkSignSelected",
+    },
+    right_deselected = {
+      name = "HunkLineRightDeselected",
       hl = "HunkSignDeselected",
     },
     partially_selected = {
@@ -33,14 +41,24 @@ end
 function M.define_signs()
   vim.fn.sign_define({
     {
-      name = M.signs.selected.name,
-      text = config.icons.selected,
-      texthl = M.signs.selected.hl,
+      name = M.signs.left_selected.name,
+      text = config.icons.left.selected,
+      texthl = M.signs.left_selected.hl,
     },
     {
-      name = M.signs.deselected.name,
-      text = config.icons.deselected,
-      texthl = M.signs.deselected.hl,
+      name = M.signs.left_deselected.name,
+      text = config.icons.left.deselected,
+      texthl = M.signs.left_deselected.hl,
+    },
+    {
+      name = M.signs.right_selected.name,
+      text = config.icons.right.selected,
+      texthl = M.signs.right_selected.hl,
+    },
+    {
+      name = M.signs.right_deselected.name,
+      text = config.icons.right.deselected,
+      texthl = M.signs.right_deselected.hl,
     },
     {
       name = M.signs.partially_selected.name,

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -41,12 +41,18 @@ local M = {
   },
 
   icons = {
-    selected = "󰡖",
-    deselected = "",
+    left = {
+      selected = "󰄱",     -- Circle outline (excluded from output)
+      deselected = "󰄮",   -- Circle filled (kept in output)
+    },
+    right = {
+      selected = "󰐖",     -- Plus box (added to output)
+      deselected = "󰄱",   -- Circle outline (ignored)
+    },
     partially_selected = "󰛲",
 
-    folder_open = "",
-    folder_closed = "",
+    folder_open = "",
+    folder_closed = "",
   },
 
   hooks = {

--- a/lua/hunk/ui/file.lua
+++ b/lua/hunk/ui/file.lua
@@ -220,9 +220,9 @@ function M.create(window, params)
         local is_selected = params.change.selected_lines[params.side][i]
         local sign
         if is_selected then
-          sign = api.signs.signs.selected
+          sign = api.signs.signs[params.side .. "_selected"]
         else
-          sign = api.signs.signs.deselected
+          sign = api.signs.signs[params.side .. "_deselected"]
         end
         api.signs.place_sign(buf, sign, i)
       end


### PR DESCRIPTION
- Split selected/deselected signs into left_* and right_* variants
- Update icons to reflect semantic meaning:
  - left.selected (󰄱): Circle outline - excluded from output
  - left.deselected (󰄮): Circle filled - kept in output  
  - right.selected (󰐖): Plus box - added to output
  - right.deselected (󰄱): Circle outline - ignored
- Update sign placement logic to use side-specific signs