### PR TITLE
feat: add config option to disable file icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,18 @@ hunk.setup({
   },
 
   icons = {
+    enable_file_icons = true,
+
     selected = "󰡖",
     deselected = "",
     partially_selected = "󰛲",
 
     folder_open = "",
     folder_closed = "",
-  },
 
+    expanded = "",
+    collapsed = "",
+  },
   -- Called right after each window and buffer are created.
   hooks = {
     ---@param _context { buf: number, tree: NuiTree, opts: table }

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -41,12 +41,17 @@ local M = {
   },
 
   icons = {
+    enable_file_icons = true,
+
     selected = "󰡖",
     deselected = "",
     partially_selected = "󰛲",
 
     folder_open = "",
     folder_closed = "",
+
+    expanded = "",
+    collapsed = "",
   },
 
   hooks = {

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -15,6 +15,10 @@ local function get_file_extension(path)
 end
 
 local function get_icon(path)
+  if not config.icons.enable_file_icons then
+    return nil
+  end
+
   local has_mini_icons, mini_icons = pcall(require, "mini.icons")
 
   if has_mini_icons then
@@ -174,9 +178,11 @@ function M.create(opts)
 
       if node:has_children() then
         if node:is_expanded() then
-          line:append(" ", "Comment")
+          local icon = config.icons.expanded or ""
+          line:append(icon .. " ", "Comment")
         else
-          line:append(" ", "Comment")
+          local icon = config.icons.collapsed or ""
+          line:append(icon .. " ", "Comment")
         end
       else
         line:append("  ")


### PR DESCRIPTION
Add the `icons.enable_file_icons` option (defaulting to true) and indicators for `icons.expanded` and `icons.collapsed` to the config.
