### PR TITLE
Add option to show confirmation before quitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ hunk.setup({
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",
+    --- Show a confirmation before quitting
+    confirm_before_quit = false,
   },
 
   icons = {

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -38,6 +38,8 @@ local M = {
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",
+    --- Show a confirmation before quitting
+    confirm_before_quit = false,
   },
 
   icons = {

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -127,7 +127,17 @@ local function set_global_bindings(layout, buf)
   end
 
   for _, chord in ipairs(utils.into_table(config.keys.global.quit)) do
-    map("n", chord, vim.cmd.cq, "Cancel selection and quit")
+    map("n", chord, function()
+      if config.ui.confirm_before_quit then
+        vim.ui.select({ "Yes", "No" }, { prompt = "Quit without saving?" }, function(choice)
+          if choice == "Yes" then
+            vim.cmd.cq()
+          end
+        end)
+      else
+        vim.cmd.cq()
+      end
+    end, "Cancel selection and quit")
   end
 
   for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do


### PR DESCRIPTION
Hi, thank you for creating this plugin. I figured it would be nice to show a confirmation when quitting, in case you had some selections made but accidentally pressed <kbd>q</kbd>.

In this change, `ui.confirm_before_quit` (default to `false`) is added. Please feel free to change the configuration key, since I wasn't sure if it belongs to `ui`. Thank you!