### PR TITLE
feat: `next_file` and `prev_file` keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ hunk.setup({
       open_file = { "<Cr>" },
 
       toggle_file = { "a" },
+
+      prev_file = { "[f" },
+      next_file = { "]f" },
     },
 
     diff = {

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -13,6 +13,9 @@ local M = {
       open_file = { "<Cr>" },
 
       toggle_file = { "a" },
+
+      prev_file = { "[f" },
+      next_file = { "]f" },
     },
 
     diff = {

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -151,25 +151,6 @@ local function open_file(layout, tree, change)
   local left_file
   local right_file
 
-  ---@param direction "prev" | "next"
-  local function navigate_to_file(direction)
-    local current_idx = tree.get_file_index(left_file.change.filepath)
-    if not current_idx then
-      return
-    end
-
-    local target_idx = utils.calc_navigate_idx(current_idx, direction, tree.get_file_count())
-    if not target_idx then
-      return
-    end
-
-    local target_change = tree.get_file_by_index(target_idx)
-    local win = vim.api.nvim_get_current_win()
-    open_file(layout, tree, target_change)
-    vim.api.nvim_set_current_win(win)
-    tree.navigate_to_file(target_change.filepath)
-  end
-
   local function on_file_event(event)
     if event.type == "toggle-lines" then
       if event.both_sides then
@@ -202,8 +183,7 @@ local function open_file(layout, tree, change)
     end
 
     if event.type == "navigate-file" then
-      navigate_to_file(event.direction)
-      return
+      tree.navigate_to_file(event.direction)
     end
   end
 

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -151,6 +151,25 @@ local function open_file(layout, tree, change)
   local left_file
   local right_file
 
+  ---@param direction "prev" | "next"
+  local function navigate_to_file(direction)
+    local current_idx = tree.get_file_index(left_file.change.filepath)
+    if not current_idx then
+      return
+    end
+
+    local target_idx = utils.calc_navigate_idx(current_idx, direction, tree.get_file_count())
+    if not target_idx then
+      return
+    end
+
+    local target_change = tree.get_file_by_index(target_idx)
+    local win = vim.api.nvim_get_current_win()
+    open_file(layout, tree, target_change)
+    vim.api.nvim_set_current_win(win)
+    tree.navigate_to_file(target_change.filepath)
+  end
+
   local function on_file_event(event)
     if event.type == "toggle-lines" then
       if event.both_sides then
@@ -179,6 +198,12 @@ local function open_file(layout, tree, change)
         win = right_file.win
       end
       vim.api.nvim_set_current_win(win)
+      return
+    end
+
+    if event.type == "navigate-file" then
+      navigate_to_file(event.direction)
+      return
     end
   end
 

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -182,8 +182,8 @@ local function open_file(layout, tree, change)
       return
     end
 
-    if event.type == "navigate-file" then
-      tree.navigate_to_file(event.direction)
+    if event.type == "nav-file" then
+      tree.nav_to_file(event.direction)
     end
   end
 

--- a/lua/hunk/ui/file.lua
+++ b/lua/hunk/ui/file.lua
@@ -210,6 +210,24 @@ function M.create(window, params)
     end, map_opts("Toggle focused window between left/right"))
   end
 
+  for _, chord in ipairs(utils.into_table(config.keys.tree.prev_file)) do
+    vim.keymap.set("n", chord, function()
+      params.on_event({
+        type = "navigate-file",
+        direction = "prev",
+      })
+    end, map_opts("Go to prev file"))
+  end
+
+  for _, chord in ipairs(utils.into_table(config.keys.tree.next_file)) do
+    vim.keymap.set("n", chord, function()
+      params.on_event({
+        type = "navigate-file",
+        direction = "next",
+      })
+    end, map_opts("Go to next file"))
+  end
+
   config.hooks.on_diff_mount({ buf = buf, win = window })
 
   local function apply_signs()

--- a/lua/hunk/ui/file.lua
+++ b/lua/hunk/ui/file.lua
@@ -213,7 +213,7 @@ function M.create(window, params)
   for _, chord in ipairs(utils.into_table(config.keys.tree.prev_file)) do
     vim.keymap.set("n", chord, function()
       params.on_event({
-        type = "navigate-file",
+        type = "nav-file",
         direction = "prev",
       })
     end, map_opts("Go to prev file"))
@@ -222,7 +222,7 @@ function M.create(window, params)
   for _, chord in ipairs(utils.into_table(config.keys.tree.next_file)) do
     vim.keymap.set("n", chord, function()
       params.on_event({
-        type = "navigate-file",
+        type = "nav-file",
         direction = "next",
       })
     end, map_opts("Go to next file"))

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -316,7 +316,7 @@ function M.create(opts)
   end
 
   ---@param direction "prev" | "next"
-  local function navigate_to_file(direction)
+  function Component.navigate_to_file(direction)
     local current = get_current_file()
     if not current then
       return
@@ -332,19 +332,24 @@ function M.create(opts)
     local _, linenr = find_node_by_filepath(tree, target_change.filepath)
     if linenr then
       vim.api.nvim_win_set_cursor(opts.winid, { linenr, 0 })
-      opts.on_preview(target_change, callback_opts)
     end
+
+    local _callback_opts = vim.tbl_extend("force", callback_opts, {
+      win = vim.api.nvim_get_current_win(),
+    })
+
+    opts.on_preview(target_change, _callback_opts)
   end
 
   for _, chord in ipairs(utils.into_table(config.keys.tree.prev_file)) do
     map("n", chord, function()
-      navigate_to_file("prev")
+      Component.navigate_to_file("prev")
     end, "Go to prev file")
   end
 
   for _, chord in ipairs(utils.into_table(config.keys.tree.next_file)) do
     map("n", chord, function()
-      navigate_to_file("next")
+      Component.navigate_to_file("next")
     end, "Go to next file")
   end
 
@@ -373,7 +378,7 @@ function M.create(opts)
   end
 
   ---@param filepath string
-  function Component.navigate_to_file(filepath)
+  function Component.navigate_to_filepath(filepath)
     local _, linenr = find_node_by_filepath(tree, filepath)
     if linenr then
       vim.api.nvim_win_set_cursor(opts.winid, { linenr, 0 })

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -316,7 +316,7 @@ function M.create(opts)
   end
 
   ---@param direction "prev" | "next"
-  function Component.navigate_to_file(direction)
+  function Component.nav_to_file(direction)
     local current = get_current_file()
     if not current then
       return
@@ -343,13 +343,13 @@ function M.create(opts)
 
   for _, chord in ipairs(utils.into_table(config.keys.tree.prev_file)) do
     map("n", chord, function()
-      Component.navigate_to_file("prev")
+      Component.nav_to_file("prev")
     end, "Go to prev file")
   end
 
   for _, chord in ipairs(utils.into_table(config.keys.tree.next_file)) do
     map("n", chord, function()
-      Component.navigate_to_file("next")
+      Component.nav_to_file("next")
     end, "Go to next file")
   end
 
@@ -378,7 +378,7 @@ function M.create(opts)
   end
 
   ---@param filepath string
-  function Component.navigate_to_filepath(filepath)
+  function Component.nav_to_filepath(filepath)
     local _, linenr = find_node_by_filepath(tree, filepath)
     if linenr then
       vim.api.nvim_win_set_cursor(opts.winid, { linenr, 0 })

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -284,7 +284,69 @@ function M.create(opts)
     end, "Toggle all hunks in file under cursor")
   end
 
-  config.hooks.on_tree_mount({ buf = buf, tree = tree, opts = opts })
+  local all_files = {}
+  ---@type table<string, integer>
+  local filepath_to_idx = {}
+
+  local function collect_files_from_tree(nodes)
+    for _, node in ipairs(nodes) do
+      if node.type == "file" then
+        table.insert(all_files, node.change)
+        filepath_to_idx[node.change.filepath] = #all_files
+      end
+      if node.children and #node.children > 0 then
+        collect_files_from_tree(node.children)
+      end
+    end
+  end
+
+  local function get_current_file()
+    local current = tree:get_node()
+    if current and current.type == "file" then
+      return current.change
+    end
+    local cursor_line = vim.api.nvim_win_get_cursor(opts.winid)[1]
+    for _, change in ipairs(all_files) do
+      local _, linenr = find_node_by_filepath(tree, change.filepath)
+      if linenr and linenr >= cursor_line then
+        return change
+      end
+    end
+    return all_files[1]
+  end
+
+  ---@param direction "prev" | "next"
+  local function navigate_to_file(direction)
+    local current = get_current_file()
+    if not current then
+      return
+    end
+
+    local current_idx = filepath_to_idx[current.filepath]
+    local target_idx = utils.calculate_navigation_idx(current_idx, direction, #all_files)
+    if not target_idx then
+      return
+    end
+
+    local target_change = all_files[target_idx]
+    local _, linenr = find_node_by_filepath(tree, target_change.filepath)
+    if linenr then
+      vim.api.nvim_win_set_cursor(opts.winid, { linenr, 0 })
+      opts.on_preview(target_change, callback_opts)
+    end
+  end
+
+  for _, chord in ipairs(utils.into_table(config.keys.tree.prev_file)) do
+    map("n", chord, function()
+      navigate_to_file("prev")
+    end, "Go to prev file")
+  end
+
+  for _, chord in ipairs(utils.into_table(config.keys.tree.next_file)) do
+    map("n", chord, function()
+      navigate_to_file("next")
+    end, "Go to next file")
+  end
 
   local file_tree
   if config.ui.tree.mode == "nested" then
@@ -298,6 +360,8 @@ function M.create(opts)
   tree:set_nodes(file_tree_to_nodes(file_tree))
   Component.render()
 
+  collect_files_from_tree(file_tree)
+
   local selected_file = file_tree_api.find_first_file_in_tree(file_tree)
   if selected_file then
     local _, selected_linenr = find_node_by_filepath(tree, selected_file.change.filepath)
@@ -307,6 +371,16 @@ function M.create(opts)
 
     opts.on_preview(selected_file.change, callback_opts)
   end
+
+  ---@param filepath string
+  function Component.navigate_to_file(filepath)
+    local _, linenr = find_node_by_filepath(tree, filepath)
+    if linenr then
+      vim.api.nvim_win_set_cursor(opts.winid, { linenr, 0 })
+    end
+  end
+
+  config.hooks.on_tree_mount({ buf = buf, tree = tree, opts = opts })
 
   return Component
 end

--- a/lua/hunk/utils.lua
+++ b/lua/hunk/utils.lua
@@ -90,4 +90,13 @@ function M.any_lines_selected(change)
   return false
 end
 
+function M.calculate_navigation_idx(current_idx, direction, file_count)
+  local delta = direction == "prev" and -1 or 1
+  local target_idx = current_idx + delta
+  if target_idx < 1 or target_idx > file_count then
+    return nil
+  end
+  return target_idx
+end
+
 return M


### PR DESCRIPTION
Implements #43.

Adds `next_file` and `prev_file` keymaps, defaulting to `[f` and `]f` respectively to match hunk navigation.
This is a rough draft, but I think it could be very useful to replace manually navigating the file tree.

Some improvements I think I could make:
- Highlight the current file in the file tree
- Make `navigate_to_file` shared, make `file.lua` call an event instead of having its own implementation

Disclaimer: Iterated on this with AI, so code is far from perfect.