### PR TITLE
Support floating window for tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ hunk.setup({
     global = {
       quit = { "q" },
       accept = { "<leader><Cr>" },
+      -- In float mode this toggles the tree open/closed; in split mode it focuses it
       focus_tree = { "<leader>e" },
     },
 
@@ -87,7 +88,25 @@ hunk.setup({
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
+      -- Width of the tree (or float). 0 = auto-fit, 0 < n <= 1 = fraction of editor width, n > 1 = columns
       width = 35,
+      -- When true the file tree opens as a floating window instead of a fixed split
+      use_float = false,
+      float = {
+        -- Height of the floating window.
+        -- 0 = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = 0,
+        -- Border style: "rounded", "single", "double", "solid", "shadow", "none",
+        -- or a custom array of border characters (see nui.popup docs)
+        border = "rounded",
+        -- Where to place the float: "left", "right", or "center"
+        -- left/right are top-aligned; center is fully centered
+        position = "left",
+        -- Padding inside the float border: top/right/bottom/left
+        padding = { left = 1, right = 1 },
+        -- Keys to close the floating tree
+        close = { "<Esc>" },
+      },
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ hunk.setup({
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
-      -- Width of the tree (or float). 0 = auto-fit, 0 < n <= 1 = fraction of editor width, n > 1 = columns
+      -- Width of the tree (or float). "auto" = auto-fit, 0 < n <= 1 = fraction of editor width, n > 1 = columns
       width = 35,
       -- When true the file tree opens as a floating window instead of a fixed split
       use_float = false,
       float = {
         -- Height of the floating window.
-        -- 0 = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
-        height = 0,
+        -- "auto" = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = "auto",
         -- Border style: "rounded", "single", "double", "solid", "shadow", "none",
         -- or a custom array of border characters (see nui.popup docs)
         border = "rounded",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ hunk.setup({
     global = {
       quit = { "q" },
       accept = { "<leader><Cr>" },
+      -- In float mode this toggles the tree open/closed; in split mode it focuses it
       focus_tree = { "<leader>e" },
     },
 
@@ -87,7 +88,26 @@ hunk.setup({
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
+      -- Width of the tree (or float). 0 < n <= 1 = fraction of editor width, n > 1 = columns
       width = 35,
+      -- When true the file tree opens as a floating window instead of a fixed split
+      use_float = false,
+      float = {
+        -- Height of the floating window.
+        -- 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = 1.0,
+        -- Border style: nil, "rounded", "single", "double", "solid", "shadow", "none",
+        -- or a custom array of border characters (see nui.popup docs).
+        -- nil: use value of vim.o.winborder
+        border = nil,
+        -- Where to place the float: "left", "right", or "center"
+        -- left/right are top-aligned; center is fully centered
+        position = "left",
+        -- Padding inside the float border: top/right/bottom/left
+        padding = { left = 1, right = 1 },
+        -- Keys to close the floating tree
+        close = { "<Esc>" },
+      },
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -34,13 +34,13 @@ local M = {
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
-      -- Width of the tree (or float). 0 = auto-fit, 0 < n <= 1 = fraction of editor, n > 1 = columns
+      -- Width of the tree (or float). "auto" (or 0) = auto-fit, 0 < n <= 1 = fraction of editor, n > 1 = columns
       width = 35,
       use_float = false,
       float = {
         -- Height of the floating window.
-        -- 0 = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
-        height = 0,
+        -- "auto" (or 0) = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = 1.0,
         -- Border style: "rounded", "single", "double", "solid", "shadow", "none",
         -- or a custom array of border characters (see nui.popup docs)
         border = "rounded",

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -34,7 +34,24 @@ local M = {
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
+      -- Width of the tree (or float). 0 = auto-fit, 0 < n <= 1 = fraction of editor, n > 1 = columns
       width = 35,
+      use_float = false,
+      float = {
+        -- Height of the floating window.
+        -- 0 = auto-fit to content, 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = 0,
+        -- Border style: "rounded", "single", "double", "solid", "shadow", "none",
+        -- or a custom array of border characters (see nui.popup docs)
+        border = "rounded",
+        -- Where to place the float: "left", "right", or "center"
+        -- left/right are top-aligned; center is fully centered.
+        position = "left",
+        -- Padding inside the float border: top/right/bottom/left
+        padding = { left = 1, right = 1 },
+        -- Keys to close the floating tree
+        close = { "<Esc>" },
+      },
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -88,7 +88,25 @@ local M = {
     tree = {
       -- Mode can either be `nested` or `flat`
       mode = "nested",
+      -- Width of the tree (or float). 0 < n <= 1 = fraction of editor width, n > 1 = columns
       width = 35,
+      use_float = false,
+      float = {
+        -- Height of the floating window.
+        -- 0 < n <= 1 = fraction of editor height, n > 1 = lines
+        height = 1.0,
+        -- Border style: nil, "rounded", "single", "double", "solid", "shadow", "none",
+        -- or a custom array of border characters (see nui.popup docs).
+        -- nil: use value of vim.o.winborder
+        border = nil,
+        -- Where to place the float: "left", "right", or "center"
+        -- left/right are top-aligned; center is fully centered.
+        position = "left",
+        -- Padding inside the float border: top/right/bottom/left
+        padding = { left = 1, right = 1 },
+        -- Keys to close the floating tree
+        close = { "<Esc>" },
+      },
     },
     --- Can be either `vertical` or `horizontal`
     layout = "vertical",
@@ -118,8 +136,33 @@ local M = {
   },
 }
 
+local function validate_positive_number(value, config_path)
+  if type(value) ~= "number" or value <= 0 then
+    error("Expected positive number for config entry `" .. config_path .. "`")
+  end
+end
+
+local function validate_enum(value, allowed_values, config_path)
+  for _, allowed in ipairs(allowed_values) do
+    if value == allowed then
+      return
+    end
+  end
+
+  error("Unknown value '" .. tostring(value) .. "' for config entry `" .. config_path .. "`")
+end
+
+local function validate_config(config)
+  validate_enum(config.ui.layout, { "vertical", "horizontal" }, "ui.layout")
+  validate_enum(config.ui.tree.mode, { "nested", "flat" }, "ui.tree.mode")
+  validate_enum(config.ui.tree.float.position, { "left", "right", "center" }, "ui.tree.float.position")
+  validate_positive_number(config.ui.tree.width, "ui.tree.width")
+  validate_positive_number(config.ui.tree.float.height, "ui.tree.float.height")
+end
+
 function M.update_config(new_config)
   local config = vim.tbl_deep_extend("force", M, new_config)
+  validate_config(config)
   for key, value in pairs(config) do
     M[key] = value
   end

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -108,7 +108,7 @@ local function toggle_hunk(change, side, line)
   toggle_lines(change, "right", right_lines, not any_selected)
 end
 
-local function set_global_bindings(layout, buf)
+local function set_global_bindings(layout, buf, tree_component)
   local function map(mode, lhs, rhs, desc)
     vim.keymap.set(mode, lhs, rhs, {
       buffer = buf,
@@ -142,12 +142,22 @@ local function set_global_bindings(layout, buf)
 
   for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do
     map("n", chord, function()
-      vim.api.nvim_set_current_win(layout.tree)
-    end, "Focus hunk.nvim file-tree")
+      tree_component.toggle()
+    end, "Focus or toggle (for float) hunk.nvim file-tree")
+  end
+
+  -- For the tree buffer in float mode, register close bindings after quit so
+  -- they shadow any overlapping key (e.g. both quit and close bound to <Esc>).
+  if config.ui.tree.use_float and buf == tree_component.buf then
+    for _, chord in ipairs(utils.into_table(config.ui.tree.float.close)) do
+      map("n", chord, function()
+        tree_component.close()
+      end, "Close tree float")
+    end
   end
 end
 
-local function open_file(layout, tree, change)
+local function open_file(layout, tree_component, change)
   local left_file
   local right_file
 
@@ -161,7 +171,7 @@ local function open_file(layout, tree, change)
         toggle_lines(change, event.file.side, event.lines)
         event.file.render()
       end
-      tree.render()
+      tree_component.render()
       return
     end
 
@@ -169,7 +179,7 @@ local function open_file(layout, tree, change)
       toggle_hunk(change, event.file.side, event.line)
       left_file.render()
       right_file.render()
-      tree.render()
+      tree_component.render()
       return
     end
 
@@ -194,8 +204,8 @@ local function open_file(layout, tree, change)
     on_event = on_file_event,
   })
 
-  set_global_bindings(layout, left_file.buf)
-  set_global_bindings(layout, right_file.buf)
+  set_global_bindings(layout, left_file.buf, tree_component)
+  set_global_bindings(layout, right_file.buf, tree_component)
 
   return left_file, right_file
 end
@@ -228,11 +238,14 @@ function M.start(left, right, output)
     changeset = changeset,
     on_open = function(change, opts)
       left_file, right_file = open_file(layout, opts.tree, change)
+      if config.ui.tree.use_float then
+        opts.tree.close()
+      end
       vim.api.nvim_set_current_win(layout.right)
     end,
     on_preview = function(change, opts)
       left_file, right_file = open_file(layout, opts.tree, change)
-      vim.api.nvim_set_current_win(layout.tree)
+      opts.tree.focus()
     end,
     on_toggle = function(change, value, opts)
       toggle_file(change, value)
@@ -245,7 +258,7 @@ function M.start(left, right, output)
 
   tree.render()
 
-  set_global_bindings(layout, tree.buf)
+  set_global_bindings(layout, tree.buf, tree)
 end
 
 function M.setup(opts)

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -256,6 +256,10 @@ function M.start(left, right, output)
     end,
   })
 
+  if layout.tree then
+    ui.layout.resize_tree(layout.tree, layout.left, layout.right, tree.width, config.ui.layout)
+  end
+
   tree.render()
 
   set_global_bindings(layout, tree.buf, tree)

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -109,7 +109,7 @@ local function toggle_hunk(change, side, line)
   toggle_lines(change, "right", right_lines, not any_selected)
 end
 
-local function set_global_bindings(layout, buf)
+local function set_global_bindings(layout, buf, tree)
   local function map(mode, lhs, rhs, desc)
     vim.keymap.set(mode, lhs, rhs, {
       buffer = buf,
@@ -143,8 +143,18 @@ local function set_global_bindings(layout, buf)
 
   for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do
     map("n", chord, function()
-      vim.api.nvim_set_current_win(layout.tree)
-    end, "Focus hunk.nvim file-tree")
+      tree.toggle()
+    end, "Focus or toggle (for float) hunk.nvim file-tree")
+  end
+
+  -- For the tree buffer in float mode, register close bindings after quit so
+  -- they shadow any overlapping key (e.g. both quit and close bound to <Esc>).
+  if config.ui.tree.use_float and buf == tree.buf then
+    for _, chord in ipairs(utils.into_table(config.ui.tree.float.close)) do
+      map("n", chord, function()
+        tree.close()
+      end, "Close tree float")
+    end
   end
 end
 
@@ -195,8 +205,8 @@ local function open_file(layout, tree, change)
     on_event = on_file_event,
   })
 
-  set_global_bindings(layout, left_file.buf)
-  set_global_bindings(layout, right_file.buf)
+  set_global_bindings(layout, left_file.buf, tree)
+  set_global_bindings(layout, right_file.buf, tree)
 
   return left_file, right_file
 end
@@ -226,6 +236,7 @@ function M.start(left, right, output)
   local left_file, right_file
   local tree = ui.tree.create({
     winid = layout.tree,
+    popup = layout.tree_popup,
     changeset = changeset,
     on_open = function(change, opts)
       left_file, right_file = open_file(layout, opts.tree, change)
@@ -233,7 +244,7 @@ function M.start(left, right, output)
     end,
     on_preview = function(change, opts)
       left_file, right_file = open_file(layout, opts.tree, change)
-      vim.api.nvim_set_current_win(layout.tree)
+      opts.tree.focus()
     end,
     on_toggle = function(change, value, opts)
       toggle_file(change, value)
@@ -246,7 +257,7 @@ function M.start(left, right, output)
 
   tree.render()
 
-  set_global_bindings(layout, tree.buf)
+  set_global_bindings(layout, tree.buf, tree)
 end
 
 --- Setup the plugin with user configuration.

--- a/lua/hunk/ui/layout.lua
+++ b/lua/hunk/ui/layout.lua
@@ -18,7 +18,7 @@ local function create_horizontal_split()
   return winid
 end
 
-local function resize_tree(tree, left, right, size, layout)
+function M.resize_tree(tree, left, right, size, layout)
   local total_width = vim.api.nvim_get_option_value("columns", {})
   local remaining_width = total_width - size
   local equal_width = math.floor(remaining_width / 2)
@@ -98,7 +98,6 @@ function M.create_layout()
     "HunkSignDeselected:Green",
   })
 
-  resize_tree(tree_window, left_diff, right_diff, config.ui.tree.width, config.ui.layout)
   vim.api.nvim_set_option_value("winfixwidth", true, { win = tree_window })
 
   vim.api.nvim_set_current_win(tree_window)

--- a/lua/hunk/ui/layout.lua
+++ b/lua/hunk/ui/layout.lua
@@ -32,6 +32,46 @@ local function resize_tree(tree, left, right, size, layout)
 end
 
 function M.create_layout()
+  if config.ui.tree.use_float then
+    local left_diff = vim.api.nvim_get_current_win()
+    local right_diff
+    if config.ui.layout == "vertical" then
+      right_diff = create_vertical_split()
+    elseif config.ui.layout == "horizontal" then
+      right_diff = create_horizontal_split()
+    else
+      error("Unknown value '" .. config.ui.layout .. "' for config entry `ui.layout`")
+    end
+
+    highlights.set_win_hl(left_diff, {
+      "DiffAdd:HunkDiffAddAsDelete",
+      "DiffDelete:HunkDiffDeleteDim",
+      "HunkSignSelected:Red",
+      "HunkSignDeselected:Red",
+    })
+
+    highlights.set_win_hl(right_diff, {
+      "DiffDelete:HunkDiffDeleteDim",
+      "HunkSignSelected:Green",
+      "HunkSignDeselected:Green",
+    })
+
+    if config.ui.layout == "vertical" then
+      local total_width = vim.api.nvim_get_option_value("columns", {})
+      local half = math.floor(total_width / 2)
+      vim.api.nvim_win_set_width(left_diff, half)
+      vim.api.nvim_win_set_width(right_diff, half)
+    end
+
+    vim.api.nvim_set_current_win(left_diff)
+
+    return {
+      tree = nil,
+      left = left_diff,
+      right = right_diff,
+    }
+  end
+
   local tree_window = vim.api.nvim_get_current_win()
 
   local left_diff = create_vertical_split()

--- a/lua/hunk/ui/layout.lua
+++ b/lua/hunk/ui/layout.lua
@@ -1,6 +1,8 @@
 local highlights = require("hunk.api.highlights")
 local config = require("hunk.config")
 
+local NuiPopup = require("nui.popup")
+
 local M = {}
 
 local function create_vertical_split()
@@ -18,33 +20,139 @@ local function create_horizontal_split()
   return winid
 end
 
-local function resize_tree(tree, left, right, size, layout)
+local function create_right_diff_split()
+  local layouts = {
+    vertical = create_vertical_split,
+    horizontal = create_horizontal_split,
+  }
+
+  return layouts[config.ui.layout]()
+end
+
+local function resolve_dimension(value, max)
+  if value <= 1 then
+    return math.max(1, math.floor(max * value))
+  else
+    return math.floor(value)
+  end
+end
+
+local function resize_tree(tree, left, right)
   local total_width = vim.api.nvim_get_option_value("columns", {})
+  local size = resolve_dimension(config.ui.tree.width, total_width)
   local remaining_width = total_width - size
   local equal_width = math.floor(remaining_width / 2)
 
   vim.api.nvim_win_set_width(tree, size)
 
-  if layout == "vertical" then
+  if config.ui.layout == "vertical" then
     vim.api.nvim_win_set_width(left, equal_width)
     vim.api.nvim_win_set_width(right, equal_width)
   end
 end
 
-function M.create_layout()
-  local tree_window = vim.api.nvim_get_current_win()
+local function resolve_float_position(pos_cfg, width, border_w, pad, center_row)
+  -- nui treats position as the content origin; border/padding extend outward.
+  local left_extra = border_w + (pad.left or 0)
+  local right_extra = border_w + (pad.right or 0)
+  local positions = {
+    center = { row = center_row, col = "50%" },
+    left = { row = 0, col = left_extra },
+    right = { row = 0, col = math.max(0, vim.o.columns - width - right_extra) },
+  }
 
-  local left_diff = create_vertical_split()
-  local right_diff
-  if config.ui.layout == "vertical" then
-    right_diff = create_vertical_split()
-  elseif config.ui.layout == "horizontal" then
-    right_diff = create_horizontal_split()
+  return positions[pos_cfg]
+end
+
+local function create_tree_popup()
+  local float_cfg = config.ui.tree.float
+  local pad = float_cfg.padding or {}
+  local border_style = float_cfg.border or vim.o.winborder
+  if border_style == "" then
+    border_style = "none"
+  end
+  local border_w = border_style ~= "none" and 1 or 0
+  local padding_w = (pad.left or 0) + (pad.right or 0)
+  local border_h = border_w * 2 + (pad.top or 0) + (pad.bottom or 0)
+  local tabline_rows
+  if vim.o.showtabline == 2 or (vim.o.showtabline == 1 and vim.fn.tabpagenr("$") > 1) then
+    tabline_rows = 1
   else
-    error("Unknown value '" .. config.ui.layout .. "' for config entry `ui.layout`")
+    tabline_rows = 0
+  end
+  local statusline_rows = vim.o.laststatus > 0 and 1 or 0
+  local available_rows = vim.o.lines - vim.o.cmdheight - statusline_rows - tabline_rows
+  local available_columns = vim.o.columns - border_w * 2 - padding_w
+  local width = resolve_dimension(config.ui.tree.width, available_columns)
+  local height = resolve_dimension(float_cfg.height, available_rows - border_h)
+  local center_row = tabline_rows + math.floor((available_rows - height) / 2)
+
+  local popup = NuiPopup({
+    enter = true,
+    focusable = true,
+    border = { style = border_style, padding = float_cfg.padding },
+    relative = "editor",
+    position = resolve_float_position(float_cfg.position, width, border_w, pad, center_row),
+    size = { width = width, height = height },
+  })
+  popup:mount()
+
+  -- nui's QuitPre handler calls self:unmount(), which destroys the buffer
+  -- backing the NuiTree. Override unmount on this instance so :q behaves
+  -- like hide() instead. This keeps nui's BufWinEnter handler intact,
+  -- which re-registers WinClosed -> hide() after each show().
+  function popup:unmount()
+    self:hide()
   end
 
-  highlights.set_win_hl(left_diff, {
+  return popup
+end
+
+local function create_floating_window_layout()
+  local left_diff = vim.api.nvim_get_current_win()
+  local right_diff = create_right_diff_split()
+
+  if config.ui.layout == "vertical" then
+    local total_width = vim.api.nvim_get_option_value("columns", {})
+    local half = math.floor(total_width / 2)
+    vim.api.nvim_win_set_width(left_diff, half)
+    vim.api.nvim_win_set_width(right_diff, half)
+  end
+
+  local tree_popup = create_tree_popup()
+
+  return {
+    tree = tree_popup.winid,
+    tree_popup = tree_popup,
+    left = left_diff,
+    right = right_diff,
+  }
+end
+
+local function create_split_window_layout()
+  local tree_window = vim.api.nvim_get_current_win()
+  local left_diff = create_vertical_split()
+  local right_diff = create_right_diff_split()
+
+  resize_tree(tree_window, left_diff, right_diff)
+  vim.api.nvim_set_option_value("winfixwidth", true, { win = tree_window })
+
+  return {
+    tree = tree_window,
+    left = left_diff,
+    right = right_diff,
+  }
+end
+
+function M.create_layout()
+  local layout
+  if config.ui.tree.use_float then
+    layout = create_floating_window_layout()
+  else
+    layout = create_split_window_layout()
+  end
+
+  highlights.set_win_hl(layout.left, {
     "DiffAdd:HunkDiffAddAsDelete",
     "DiffDelete:HunkDiffDeleteDim",
 
@@ -52,22 +160,15 @@ function M.create_layout()
     "HunkSignDeselected:HunkSignDelete",
   })
 
-  highlights.set_win_hl(right_diff, {
+  highlights.set_win_hl(layout.right, {
     "DiffDelete:HunkDiffDeleteDim",
     "HunkSignSelected:HunkSignAdd",
     "HunkSignDeselected:HunkSignAdd",
   })
 
-  resize_tree(tree_window, left_diff, right_diff, config.ui.tree.width, config.ui.layout)
-  vim.api.nvim_set_option_value("winfixwidth", true, { win = tree_window })
+  vim.api.nvim_set_current_win(layout.tree)
 
-  vim.api.nvim_set_current_win(tree_window)
-
-  return {
-    tree = tree_window,
-    left = left_diff,
-    right = right_diff,
-  }
+  return layout
 end
 
 return M

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -222,7 +222,7 @@ local function compute_tree_width(nodes, depth, icon_widths)
 end
 
 local function resolve_dimension(value, auto_value, max)
-  if value == 0 then
+  if value == "auto" or value == 0 then
     return auto_value
   elseif value > 0 and value <= 1 then
     return math.max(1, math.floor(max * value))

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -357,8 +357,16 @@ function M.create(opts)
 
   local buf = vim.api.nvim_win_get_buf(winid)
 
+  local textoff = vim.fn.getwininfo(winid)[1].textoff or 0
+  local resolved_width = resolve_dimension(
+    config.ui.tree.width,
+    compute_tree_width(file_tree) + textoff,
+    vim.o.columns
+  )
+
   local Component = {
     buf = buf,
+    width = resolved_width,
   }
 
   function Component.render()

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -364,6 +364,8 @@ function M.create(opts)
     vim.o.columns
   )
 
+  local last_selected_path = nil
+
   local Component = {
     buf = buf,
     width = resolved_width,
@@ -394,6 +396,12 @@ function M.create(opts)
         popup.winid = nil
         popup:show()
         vim.api.nvim_set_current_win(popup.winid)
+        if last_selected_path then
+          local _, linenr = find_node_by_filepath(tree, last_selected_path)
+          if linenr then
+            vim.api.nvim_win_set_cursor(popup.winid, { linenr, 0 })
+          end
+        end
       end
     end
   else
@@ -424,6 +432,7 @@ function M.create(opts)
     map("n", chord, function()
       local node = tree:get_node()
       if node and node.type == "file" then
+        last_selected_path = node.change.filepath
         opts.on_open(node.change, callback_opts)
       end
     end, "Open file under cursor")

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -3,6 +3,7 @@ local config = require("hunk.config")
 local utils = require("hunk.utils")
 
 local NuiTree = require("nui.tree")
+local NuiPopup = require("nui.popup")
 local Text = require("nui.text")
 local Line = require("nui.line")
 
@@ -163,12 +164,153 @@ local function get_file_icon(change)
   return config.icons.deselected
 end
 
+local function count_tree_nodes(nodes)
+  local count = 0
+  for _, node in ipairs(nodes) do
+    count = count + 1
+    if node.children and #node.children > 0 then
+      count = count + count_tree_nodes(node.children)
+    end
+  end
+  return count
+end
+
+local function compute_tree_width(nodes, depth, icon_widths)
+  depth = depth or 1
+  if not icon_widths then
+    icon_widths = {
+      -- max width of expand icon slot (dir: icon + space, file: two spaces)
+      expand = math.max(
+        vim.fn.strdisplaywidth((config.icons.expanded or "") .. " "),
+        vim.fn.strdisplaywidth((config.icons.collapsed or "") .. " "),
+        2
+      ),
+      -- max width of selection icon + trailing space
+      selection = math.max(
+        vim.fn.strdisplaywidth(config.icons.selected .. " "),
+        vim.fn.strdisplaywidth(config.icons.deselected .. " "),
+        vim.fn.strdisplaywidth(config.icons.partially_selected .. " ")
+      ),
+      -- max width of folder icon + trailing space (dirs only)
+      folder = math.max(
+        vim.fn.strdisplaywidth((config.icons.folder_open or "") .. " "),
+        vim.fn.strdisplaywidth((config.icons.folder_closed or "") .. " ")
+      ),
+      -- file type icon + trailing space (e.g. devicons); 0 when disabled
+      file_icon = config.icons.enable_file_icons and 2 or 0,
+    }
+  end
+  local max_width = 0
+  for _, node in ipairs(nodes) do
+    local is_dir = node.children ~= nil
+    local overhead = (depth - 1) * 2
+      + icon_widths.expand
+      + icon_widths.selection
+      + (is_dir and icon_widths.folder or icon_widths.file_icon)
+    local w = overhead + vim.fn.strdisplaywidth(node.name)
+    if w > max_width then
+      max_width = w
+    end
+    if is_dir and #node.children > 0 then
+      local child_max = compute_tree_width(node.children, depth + 1, icon_widths)
+      if child_max > max_width then
+        max_width = child_max
+      end
+    end
+  end
+  return max_width
+end
+
+local function resolve_dimension(value, auto_value, max)
+  if value == 0 then
+    return auto_value
+  elseif value > 0 and value <= 1 then
+    return math.max(1, math.floor(max * value))
+  else
+    return math.floor(value)
+  end
+end
+
+local function resolve_float_position(pos_cfg, width, border_w, pad)
+  -- nui treats position as the content origin; border/padding extend outward.
+  local left_extra = border_w + (pad.left or 0)
+  local right_extra = border_w + (pad.right or 0)
+  local positions = {
+    center = { row = "50%", col = "50%" },
+    left   = { row = 0, col = left_extra },
+    right  = { row = 0, col = math.max(0, vim.o.columns - width - right_extra) },
+  }
+
+  local pos = positions[pos_cfg]
+  if not pos then
+    error("Unknown value '" .. tostring(pos_cfg) .. "' for config entry `ui.tree.float.position`")
+  end
+  return pos
+end
+
 local M = {}
 
 function M.create(opts)
+  local is_float = config.ui.tree.use_float
+
+  -- Build the file tree early so auto-width can use it
+  local file_tree
+  if config.ui.tree.mode == "flat" then
+    file_tree = file_tree_api.build_flat_file_tree(opts.changeset)
+  elseif config.ui.tree.mode == "nested" then
+    file_tree = file_tree_api.build_file_tree(opts.changeset)
+  else
+    error("Unknown value '" .. config.ui.tree.mode .. "' for config entry `ui.tree.mode`")
+  end
+
+  local popup = nil
+  local winid = opts.winid
+
+  if is_float then
+    local float_cfg = config.ui.tree.float
+    local pad = float_cfg.padding or {}
+    local border_w = float_cfg.border ~= "none" and 1 or 0
+    local padding_w = (pad.left or 0) + (pad.right or 0)
+    local border_h = border_w * 2 + (pad.top or 0) + (pad.bottom or 0)
+    local tabline_rows = (vim.o.showtabline == 2
+      or (vim.o.showtabline == 1 and vim.fn.tabpagenr("$") > 1)) and 1 or 0
+    local statusline_rows = vim.o.laststatus > 0 and 1 or 0
+    local available_rows = vim.o.lines - vim.o.cmdheight - statusline_rows - tabline_rows
+    local float_width = resolve_dimension(
+      config.ui.tree.width,
+      compute_tree_width(file_tree) + padding_w,
+      vim.o.columns - border_w * 2 - padding_w
+    )
+    local float_height = resolve_dimension(
+      float_cfg.height,
+      count_tree_nodes(file_tree),
+      available_rows - border_h
+    )
+
+    popup = NuiPopup({
+      enter = true,
+      focusable = true,
+      border = { style = float_cfg.border, padding = float_cfg.padding },
+      relative = "editor",
+      position = resolve_float_position(float_cfg.position, float_width, border_w, pad),
+      size = { width = float_width, height = float_height },
+    })
+    popup:mount()
+    winid = popup.winid
+    -- nui's QuitPre handler calls self:unmount(), which destroys the buffer
+    -- backing the NuiTree. Override unmount on this instance so :q behaves
+    -- like hide() instead. This keeps nui's BufWinEnter handler intact,
+    -- which re-registers WinClosed → hide() after each show().
+    function popup:unmount()
+      self:hide()
+    end
+  elseif not winid then
+    error("opts.winid is required when use_float is false")
+  end
+
   local tree = NuiTree({
-    winid = opts.winid,
-    bufnr = vim.api.nvim_win_get_buf(opts.winid),
+    winid = winid,
+    bufnr = vim.api.nvim_win_get_buf(winid),
     nodes = {},
 
     prepare_node = function(node)
@@ -213,7 +355,7 @@ function M.create(opts)
     end,
   })
 
-  local buf = vim.api.nvim_win_get_buf(opts.winid)
+  local buf = vim.api.nvim_win_get_buf(winid)
 
   local Component = {
     buf = buf,
@@ -221,6 +363,43 @@ function M.create(opts)
 
   function Component.render()
     tree:render()
+  end
+
+  if is_float then
+    function Component.focus()
+      if popup.winid and vim.api.nvim_win_is_valid(popup.winid) then
+        vim.api.nvim_set_current_win(popup.winid)
+      end
+    end
+
+    function Component.close()
+      if popup.winid and vim.api.nvim_win_is_valid(popup.winid) then
+        popup:hide()
+      end
+    end
+
+    function Component.toggle()
+      if popup.winid and vim.api.nvim_win_is_valid(popup.winid) then
+        popup:hide()
+      else
+        -- Clear stale winid so _open_window() doesn't short-circuit
+        popup.winid = nil
+        popup:show()
+        vim.api.nvim_set_current_win(popup.winid)
+      end
+    end
+  else
+    function Component.focus()
+      vim.api.nvim_set_current_win(winid)
+    end
+
+    function Component.close()
+      -- no-op for embedded modes
+    end
+
+    function Component.toggle()
+      vim.api.nvim_set_current_win(winid)
+    end
   end
 
   local callback_opts = { tree = Component }
@@ -286,15 +465,6 @@ function M.create(opts)
 
   config.hooks.on_tree_mount({ buf = buf, tree = tree, opts = opts })
 
-  local file_tree
-  if config.ui.tree.mode == "nested" then
-    file_tree = file_tree_api.build_file_tree(opts.changeset)
-  elseif config.ui.tree.mode == "flat" then
-    file_tree = file_tree_api.build_flat_file_tree(opts.changeset)
-  else
-    error("Unknown value '" .. config.ui.tree("' for config entry `ui.tree.mode`"))
-  end
-
   tree:set_nodes(file_tree_to_nodes(file_tree))
   Component.render()
 
@@ -302,7 +472,7 @@ function M.create(opts)
   if selected_file then
     local _, selected_linenr = find_node_by_filepath(tree, selected_file.change.filepath)
     if selected_linenr then
-      vim.api.nvim_win_set_cursor(opts.winid, { selected_linenr, 0 })
+      vim.api.nvim_win_set_cursor(winid, { selected_linenr, 0 })
     end
 
     opts.on_preview(selected_file.change, callback_opts)

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -166,6 +166,17 @@ end
 local M = {}
 
 function M.create(opts)
+  local is_float = config.ui.tree.use_float
+  local builders = {
+    flat = file_tree_api.build_flat_file_tree,
+    nested = file_tree_api.build_file_tree,
+  }
+  local file_tree = builders[config.ui.tree.mode](opts.changeset)
+
+  if is_float and not opts.popup then
+    error("opts.popup is required when use_float is true")
+  end
+
   local tree = NuiTree({
     winid = opts.winid,
     bufnr = vim.api.nvim_win_get_buf(opts.winid),
@@ -214,6 +225,7 @@ function M.create(opts)
   })
 
   local buf = vim.api.nvim_win_get_buf(opts.winid)
+  local last_selected_path = nil
 
   local Component = {
     buf = buf,
@@ -221,6 +233,49 @@ function M.create(opts)
 
   function Component.render()
     tree:render()
+  end
+
+  if is_float then
+    local popup = opts.popup
+
+    function Component.focus()
+      if popup.winid then
+        vim.api.nvim_set_current_win(popup.winid)
+      end
+    end
+
+    function Component.close()
+      if popup.winid then
+        popup:hide()
+      end
+    end
+
+    function Component.toggle()
+      if popup.winid then
+        popup:hide()
+      else
+        popup:show()
+        vim.api.nvim_set_current_win(popup.winid)
+        if last_selected_path then
+          local _, linenr = find_node_by_filepath(tree, last_selected_path)
+          if linenr then
+            vim.api.nvim_win_set_cursor(popup.winid, { linenr, 0 })
+          end
+        end
+      end
+    end
+  else
+    function Component.focus()
+      vim.api.nvim_set_current_win(opts.winid)
+    end
+
+    function Component.close()
+      -- no-op for embedded modes
+    end
+
+    function Component.toggle()
+      vim.api.nvim_set_current_win(opts.winid)
+    end
   end
 
   local callback_opts = { tree = Component }
@@ -237,6 +292,8 @@ function M.create(opts)
     map("n", chord, function()
       local node = tree:get_node()
       if node and node.type == "file" then
+        last_selected_path = node.change.filepath
+        Component.close()
         opts.on_open(node.change, callback_opts)
       end
     end, "Open file under cursor")
@@ -285,15 +342,6 @@ function M.create(opts)
   end
 
   config.hooks.on_tree_mount({ buf = buf, tree = tree, opts = opts })
-
-  local file_tree
-  if config.ui.tree.mode == "nested" then
-    file_tree = file_tree_api.build_file_tree(opts.changeset)
-  elseif config.ui.tree.mode == "flat" then
-    file_tree = file_tree_api.build_flat_file_tree(opts.changeset)
-  else
-    error("Unknown value '" .. config.ui.tree("' for config entry `ui.tree.mode`"))
-  end
 
   tree:set_nodes(file_tree_to_nodes(file_tree))
   Component.render()


### PR DESCRIPTION
I often split my terminal vertically, and find the tree takes up too much space. This PR adds the ability to open the tree in a floating window via the `ui.tree.use_float` option. There is also an `auto` option for the width to determine the dimension of the tree window based on the content. I realized too late after implementing that it may have been better to split this into a different PR, but if you prefer I can try to split it.

If you have any preference regarding the naming / default values please let me know and I will update.

Disclaimer: I’ve used Claude to add this feature, but have tested all options quite extensively myself.

Squash plan:
- 8971e97, d5bcd31, 2deecb3, and 6216688: all related to floating window; squash into one commit
- 0fa4863: affects non-float tree windows, so leave as its own.