### PR TITLE
refactor(api): extract public hunk-manipulation API and expand hooks

### DIFF
--- a/lua/hunk/api/actions.lua
+++ b/lua/hunk/api/actions.lua
@@ -1,0 +1,209 @@
+local changeset = require("hunk.api.changeset")
+local utils = require("hunk.utils")
+local config = require("hunk.config")
+local ui = require("hunk.ui")
+
+local M = {}
+
+local function value_or_default(value, default)
+  if value ~= nil then
+    return value
+  end
+  return default
+end
+
+local function line_is_within_hunk_bounds(hunk, side, line)
+  local start_line = hunk[side][1]
+  local end_line = start_line + hunk[side][2]
+  return line <= end_line and line >= start_line
+end
+
+local function find_hunk_at_line(hunks, side, line)
+  for _, current_hunk in ipairs(hunks) do
+    if line_is_within_hunk_bounds(current_hunk, side, line) then
+      return current_hunk
+    end
+  end
+end
+
+function M.toggle_file(change, value)
+  for _, hunk in ipairs(change.hunks) do
+    for i in utils.hunk_lines(hunk.left) do
+      change.selected_lines.left[i] = value_or_default(value, not change.selected)
+    end
+
+    for i in utils.hunk_lines(hunk.right) do
+      change.selected_lines.right[i] = value_or_default(value, not change.selected)
+    end
+  end
+
+  change.selected = value_or_default(value, not change.selected)
+end
+
+function M.toggle_lines(change, side, lines, value)
+  for _, line in ipairs(lines) do
+    if value ~= nil then
+      change.selected_lines[side][line] = value
+    else
+      change.selected_lines[side][line] = not change.selected_lines[side][line]
+    end
+  end
+
+  if utils.all_lines_selected(change) then
+    change.selected = true
+  else
+    change.selected = false
+  end
+end
+
+function M.toggle_line_pairs(change, reference_side, lines, value)
+  local hunk
+  for _, line in ipairs(lines) do
+    if not hunk or not line_is_within_hunk_bounds(hunk, reference_side, line) then
+      hunk = find_hunk_at_line(change.hunks, reference_side, line)
+    end
+
+    if value ~= nil then
+      value = change.selected_lines[reference_side][line]
+    end
+
+    if hunk then
+      M.toggle_lines(change, reference_side, { line }, value)
+
+      local opposite_side = "left"
+      if reference_side == "left" then
+        opposite_side = "right"
+      end
+
+      local offset = (hunk[reference_side][1] - line) * -1
+      if hunk[opposite_side][2] >= offset then
+        local other_line = hunk[opposite_side][1] + offset
+        M.toggle_lines(change, opposite_side, { other_line }, value)
+      end
+    end
+  end
+end
+
+function M.toggle_hunk(change, side, line)
+  local hunk = find_hunk_at_line(change.hunks, side, line)
+  if not hunk then
+    return
+  end
+
+  local left_lines = {}
+  for i in utils.hunk_lines(hunk.left) do
+    table.insert(left_lines, i)
+  end
+
+  local right_lines = {}
+  for i in utils.hunk_lines(hunk.right) do
+    table.insert(right_lines, i)
+  end
+
+  local any_selected = utils.all_lines_selected_in_hunk(change, hunk)
+
+  M.toggle_lines(change, "left", left_lines, not any_selected)
+  M.toggle_lines(change, "right", right_lines, not any_selected)
+end
+
+function M.set_global_bindings(session, buf)
+  local layout = session.layout
+  local function map(mode, lhs, rhs, desc)
+    vim.keymap.set(mode, lhs, rhs, {
+      buffer = buf,
+      desc = desc,
+      nowait = true,
+    })
+  end
+
+  map("n", "g?", ui.help.create, "Open hunk.nvim help")
+
+  for _, chord in ipairs(utils.into_table(config.keys.global.accept)) do
+    map("n", chord, function()
+      config.hooks.on_before_accept({ session = session })
+      changeset.write_changeset(session.changeset, session.output or session.right)
+      vim.cmd.qa()
+    end, "qa")
+  end
+
+  for _, chord in ipairs(utils.into_table(config.keys.global.quit)) do
+    map("n", chord, function()
+      if config.ui.confirm_before_quit then
+        vim.ui.select({ "Yes", "No" }, { prompt = "Quit without saving?" }, function(choice)
+          if choice == "Yes" then
+            config.hooks.on_before_quit({ session = session })
+            vim.cmd.cq()
+          end
+        end)
+      else
+        config.hooks.on_before_quit({ session = session })
+        vim.cmd.cq()
+      end
+    end, "Cancel selection and quit")
+  end
+
+  for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do
+    map("n", chord, function()
+      vim.api.nvim_set_current_win(layout.tree)
+    end, "Focus hunk.nvim file-tree")
+  end
+end
+
+function M.open_file(session, tree, change)
+  local layout = session.layout
+  local left_file
+  local right_file
+
+  local function on_file_event(event)
+    if event.type == "toggle-lines" then
+      if event.both_sides then
+        M.toggle_line_pairs(change, event.file.side, event.lines)
+        left_file.render()
+        right_file.render()
+      else
+        M.toggle_lines(change, event.file.side, event.lines)
+        event.file.render()
+      end
+      tree.render()
+      config.hooks.on_line_toggled({ change = change, side = event.file.side, lines = event.lines })
+      return
+    end
+
+    if event.type == "toggle-hunk" then
+      M.toggle_hunk(change, event.file.side, event.line)
+      left_file.render()
+      right_file.render()
+      tree.render()
+      config.hooks.on_hunk_toggled({ change = change, side = event.file.side, line = event.line })
+      return
+    end
+
+    if event.type == "toggle-focus" then
+      local win = left_file.win
+      if event.side == "left" then
+        win = right_file.win
+      end
+      vim.api.nvim_set_current_win(win)
+      config.hooks.on_focus_changed({ side = event.side })
+    end
+  end
+
+  left_file = ui.file.create(layout.left, {
+    side = "left",
+    change = change,
+    on_event = on_file_event,
+  })
+
+  right_file = ui.file.create(layout.right, {
+    side = "right",
+    change = change,
+    on_event = on_file_event,
+  })
+
+  M.set_global_bindings(session, left_file.buf)
+  M.set_global_bindings(session, right_file.buf)
+
+  return left_file, right_file
+end
+
+return M

--- a/lua/hunk/api/init.lua
+++ b/lua/hunk/api/init.lua
@@ -4,4 +4,5 @@ return {
   fs = require("hunk.api.fs"),
   signs = require("hunk.api.signs"),
   highlights = require("hunk.api.highlights"),
+  actions = require("hunk.api.actions"),
 }

--- a/lua/hunk/config.lua
+++ b/lua/hunk/config.lua
@@ -44,6 +44,15 @@
 ---@class hunk.Hooks
 ---@field on_tree_mount fun(context: { buf: number, tree: NuiTree, opts: table }) Called after tree buffer is mounted
 ---@field on_diff_mount fun(context: { buf: number, win: number }) Called after diff buffer is mounted
+---@field on_file_opened fun(context: { change: table, session: hunk.Session }) Called when a file is opened from the tree
+---@field on_file_previewed fun(context: { change: table, session: hunk.Session }) Called when a file is previewed from the tree
+---@field on_file_toggled fun(context: { change: table, session: hunk.Session }) Called when a file is toggled in the tree
+---@field on_line_toggled fun(context: { change: table, side: string, lines: number[] }) Called when lines are toggled in a diff view
+---@field on_hunk_toggled fun(context: { change: table, side: string, line: number }) Called when a hunk is toggled in a diff view
+---@field on_hunk_navigated fun(context: { side: string, hunk: table, change: table }) Called when navigating between hunks
+---@field on_focus_changed fun(context: { side: string }) Called when focus switches between left/right diff views
+---@field on_before_accept fun(context: { session: hunk.Session }) Called just before accepting and writing changes
+---@field on_before_quit fun(context: { session: hunk.Session }) Called just before quitting without saving
 
 ---@class hunk.Config
 ---@field keys hunk.Keys
@@ -133,6 +142,24 @@ local M = {
     on_tree_mount = function(_context) end,
     ---@param _context { buf: number, win: number }
     on_diff_mount = function(_context) end,
+    ---@param _context { change: table, session: hunk.Session }
+    on_file_opened = function(_context) end,
+    ---@param _context { change: table, session: hunk.Session }
+    on_file_previewed = function(_context) end,
+    ---@param _context { change: table, session: hunk.Session }
+    on_file_toggled = function(_context) end,
+    ---@param _context { change: table, side: string, lines: number[] }
+    on_line_toggled = function(_context) end,
+    ---@param _context { change: table, side: string, line: number }
+    on_hunk_toggled = function(_context) end,
+    ---@param _context { side: string, hunk: table, change: table }
+    on_hunk_navigated = function(_context) end,
+    ---@param _context { side: string }
+    on_focus_changed = function(_context) end,
+    ---@param _context { session: hunk.Session }
+    on_before_accept = function(_context) end,
+    ---@param _context { session: hunk.Session }
+    on_before_quit = function(_context) end,
   },
 }
 

--- a/lua/hunk/init.lua
+++ b/lua/hunk/init.lua
@@ -1,215 +1,8 @@
 local config = require("hunk.config")
-local utils = require("hunk.utils")
 local api = require("hunk.api")
 local ui = require("hunk.ui")
 
 local M = {}
-
----@type table?
-local CONTEXT
-
-local function value_or_default(value, default)
-  if value ~= nil then
-    return value
-  end
-  return default
-end
-
-local function toggle_file(change, value)
-  for _, hunk in ipairs(change.hunks) do
-    for i in utils.hunk_lines(hunk.left) do
-      change.selected_lines.left[i] = value_or_default(value, not change.selected)
-    end
-
-    for i in utils.hunk_lines(hunk.right) do
-      change.selected_lines.right[i] = value_or_default(value, not change.selected)
-    end
-  end
-
-  change.selected = value_or_default(value, not change.selected)
-end
-
-local function toggle_lines(change, side, lines, value)
-  for _, line in ipairs(lines) do
-    if value ~= nil then
-      change.selected_lines[side][line] = value
-    else
-      change.selected_lines[side][line] = not change.selected_lines[side][line]
-    end
-  end
-
-  if utils.all_lines_selected(change) then
-    change.selected = true
-  else
-    change.selected = false
-  end
-end
-
-local function line_is_within_hunk_bounds(hunk, side, line)
-  local start_line = hunk[side][1]
-  local end_line = start_line + hunk[side][2]
-  return line <= end_line and line >= start_line
-end
-
-local function find_hunk_at_line(hunks, side, line)
-  for _, current_hunk in ipairs(hunks) do
-    if line_is_within_hunk_bounds(current_hunk, side, line) then
-      return current_hunk
-    end
-  end
-end
-
-local function toggle_line_pairs(change, reference_side, lines, value)
-  local hunk
-  for _, line in ipairs(lines) do
-    if not hunk or not line_is_within_hunk_bounds(hunk, reference_side, line) then
-      hunk = find_hunk_at_line(change.hunks, reference_side, line)
-    end
-
-    if value ~= nil then
-      value = change.selected_lines[reference_side][line]
-    end
-
-    if hunk then
-      toggle_lines(change, reference_side, { line }, value)
-
-      local opposite_side = "left"
-      if reference_side == "left" then
-        opposite_side = "right"
-      end
-
-      local offset = (hunk[reference_side][1] - line) * -1
-      if hunk[opposite_side][2] >= offset then
-        local other_line = hunk[opposite_side][1] + offset
-        toggle_lines(change, opposite_side, { other_line }, value)
-      end
-    end
-  end
-end
-
-local function toggle_hunk(change, side, line)
-  local hunk = find_hunk_at_line(change.hunks, side, line)
-  if not hunk then
-    return
-  end
-
-  local left_lines = {}
-  for i in utils.hunk_lines(hunk.left) do
-    table.insert(left_lines, i)
-  end
-
-  local right_lines = {}
-  for i in utils.hunk_lines(hunk.right) do
-    table.insert(right_lines, i)
-  end
-
-  local any_selected = utils.all_lines_selected_in_hunk(change, hunk)
-
-  toggle_lines(change, "left", left_lines, not any_selected)
-  toggle_lines(change, "right", right_lines, not any_selected)
-end
-
-local function set_global_bindings(layout, buf, tree)
-  local function map(mode, lhs, rhs, desc)
-    vim.keymap.set(mode, lhs, rhs, {
-      buffer = buf,
-      desc = desc,
-      nowait = true,
-    })
-  end
-
-  map("n", "g?", ui.help.create, "Open hunk.nvim help")
-
-  for _, chord in ipairs(utils.into_table(config.keys.global.accept)) do
-    map("n", chord, function()
-      api.changeset.write_changeset(CONTEXT.changeset, CONTEXT.output or CONTEXT.right)
-      vim.cmd.qa()
-    end, "qa")
-  end
-
-  for _, chord in ipairs(utils.into_table(config.keys.global.quit)) do
-    map("n", chord, function()
-      if config.ui.confirm_before_quit then
-        vim.ui.select({ "Yes", "No" }, { prompt = "Quit without saving?" }, function(choice)
-          if choice == "Yes" then
-            vim.cmd.cq()
-          end
-        end)
-      else
-        vim.cmd.cq()
-      end
-    end, "Cancel selection and quit")
-  end
-
-  for _, chord in ipairs(utils.into_table(config.keys.global.focus_tree)) do
-    map("n", chord, function()
-      tree.toggle()
-    end, "Focus or toggle (for float) hunk.nvim file-tree")
-  end
-
-  -- For the tree buffer in float mode, register close bindings after quit so
-  -- they shadow any overlapping key (e.g. both quit and close bound to <Esc>).
-  if config.ui.tree.use_float and buf == tree.buf then
-    for _, chord in ipairs(utils.into_table(config.ui.tree.float.close)) do
-      map("n", chord, function()
-        tree.close()
-      end, "Close tree float")
-    end
-  end
-end
-
-local function open_file(layout, tree, change)
-  local left_file
-  local right_file
-
-  local function on_file_event(event)
-    if event.type == "toggle-lines" then
-      if event.both_sides then
-        toggle_line_pairs(change, event.file.side, event.lines)
-        left_file.render()
-        right_file.render()
-      else
-        toggle_lines(change, event.file.side, event.lines)
-        event.file.render()
-      end
-      tree.render()
-      return
-    end
-
-    if event.type == "toggle-hunk" then
-      toggle_hunk(change, event.file.side, event.line)
-      left_file.render()
-      right_file.render()
-      tree.render()
-      return
-    end
-
-    if event.type == "toggle-focus" then
-      local win = left_file.win
-      if event.side == "left" then
-        win = right_file.win
-      end
-      vim.api.nvim_set_current_win(win)
-    end
-  end
-
-  left_file = ui.file.create(layout.left, {
-    side = "left",
-    change = change,
-    on_event = on_file_event,
-  })
-
-  right_file = ui.file.create(layout.right, {
-    side = "right",
-    change = change,
-    on_event = on_file_event,
-  })
-
-  set_global_bindings(layout, left_file.buf, tree)
-  set_global_bindings(layout, right_file.buf, tree)
-
-  return left_file, right_file
-end
 
 local initialised = false
 
@@ -223,11 +16,18 @@ function M.start(left, right, output)
   if not initialised then
     init()
   end
-  local changeset = api.changeset.load_changeset(left, right)
-  local layout = ui.layout.create_layout()
 
-  CONTEXT = {
-    changeset = changeset,
+  ---@class hunk.Session
+  ---@field changeset table
+  ---@field layout table
+  ---@field components table
+  ---@field left string
+  ---@field right string
+  ---@field output string
+  local session = {
+    changeset = api.changeset.load_changeset(left, right),
+    layout = ui.layout.create_layout(),
+    components = {},
     left = left,
     right = right,
     output = output,
@@ -235,19 +35,23 @@ function M.start(left, right, output)
 
   local left_file, right_file
   local tree = ui.tree.create({
-    winid = layout.tree,
-    popup = layout.tree_popup,
-    changeset = changeset,
+    winid = session.layout.tree,
+    changeset = session.changeset,
+    session = session,
     on_open = function(change, opts)
-      left_file, right_file = open_file(layout, opts.tree, change)
-      vim.api.nvim_set_current_win(layout.right)
+      left_file, right_file = api.actions.open_file(session, opts.tree, change)
+      session.components.left_file = left_file
+      session.components.right_file = right_file
+      vim.api.nvim_set_current_win(session.layout.right)
     end,
     on_preview = function(change, opts)
-      left_file, right_file = open_file(layout, opts.tree, change)
-      opts.tree.focus()
+      left_file, right_file = api.actions.open_file(session, opts.tree, change)
+      session.components.left_file = left_file
+      session.components.right_file = right_file
+      vim.api.nvim_set_current_win(session.layout.tree)
     end,
     on_toggle = function(change, value, opts)
-      toggle_file(change, value)
+      api.actions.toggle_file(change, value)
 
       left_file.render()
       right_file.render()
@@ -255,9 +59,13 @@ function M.start(left, right, output)
     end,
   })
 
+  session.components.tree = tree
+
   tree.render()
 
-  set_global_bindings(layout, tree.buf, tree)
+  api.actions.set_global_bindings(session, tree.buf)
+
+  return session
 end
 
 --- Setup the plugin with user configuration.

--- a/lua/hunk/ui/file.lua
+++ b/lua/hunk/ui/file.lua
@@ -1,6 +1,7 @@
 local config = require("hunk.config")
 local utils = require("hunk.utils")
-local api = require("hunk.api")
+local signs = require("hunk.api.signs")
+local fs = require("hunk.api.fs")
 
 local M = {}
 
@@ -58,7 +59,7 @@ local function create_buffer(params)
   if file.symlink then
     lines = { file.symlink }
   else
-    lines = api.fs.read_file_as_lines(file.path)
+    lines = fs.read_file_as_lines(file.path)
   end
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 
@@ -182,6 +183,7 @@ function M.create(window, params)
         local hunk = params.change.hunks[#params.change.hunks - i + 1]
         if hunk[params.side][1] < line_num then
           vim.api.nvim_win_set_cursor(0, { hunk[params.side][1], cursor_pos[2] })
+          config.hooks.on_hunk_navigated({ side = params.side, hunk = hunk, change = params.change })
           break
         end
       end
@@ -195,6 +197,7 @@ function M.create(window, params)
       for _, hunk in ipairs(params.change.hunks) do
         if hunk[params.side][1] > line_num then
           vim.api.nvim_win_set_cursor(0, { hunk[params.side][1], cursor_pos[2] })
+          config.hooks.on_hunk_navigated({ side = params.side, hunk = hunk, change = params.change })
           break
         end
       end
@@ -213,18 +216,18 @@ function M.create(window, params)
   config.hooks.on_diff_mount({ buf = buf, win = window })
 
   local function apply_signs()
-    api.signs.clear_signs(buf)
+    signs.clear_signs(buf)
 
     for _, hunk in ipairs(params.change.hunks) do
       for i in utils.hunk_lines(hunk[params.side]) do
         local is_selected = params.change.selected_lines[params.side][i]
         local sign
         if is_selected then
-          sign = api.signs.signs.selected
+          sign = signs.signs.selected
         else
-          sign = api.signs.signs.deselected
+          sign = signs.signs.deselected
         end
-        api.signs.place_sign(buf, sign, i)
+        signs.place_sign(buf, sign, i)
       end
     end
   end

--- a/lua/hunk/ui/tree.lua
+++ b/lua/hunk/ui/tree.lua
@@ -295,6 +295,7 @@ function M.create(opts)
         last_selected_path = node.change.filepath
         Component.close()
         opts.on_open(node.change, callback_opts)
+        config.hooks.on_file_opened({ change = node.change, session = opts.session })
       end
     end, "Open file under cursor")
   end
@@ -307,6 +308,7 @@ function M.create(opts)
       end
       if node.type == "file" then
         opts.on_preview(node.change, callback_opts)
+        config.hooks.on_file_previewed({ change = node.change, session = opts.session })
       end
       if node.type == "dir" and not node:is_expanded() then
         node:expand()
@@ -330,6 +332,7 @@ function M.create(opts)
       local node = tree:get_node()
       if node and node.type == "file" then
         opts.on_toggle(node.change, nil, callback_opts)
+        config.hooks.on_file_toggled({ change = node.change, session = opts.session })
         return
       end
 


### PR DESCRIPTION
Previously all core logic (toggle_file, toggle_lines, toggle_hunk, open_file, set_global_bindings) lived as private local functions inside lua/hunk/init.lua, and a module-level mutable CONTEXT global held session state. Users could not call any of these functions directly — the only customization surface was swapping key chord strings.

This commit:

- Adds lua/hunk/api/actions.lua as the public API module, exposing toggle_file, toggle_lines, toggle_line_pairs, toggle_hunk, open_file, and set_global_bindings.
- Registers actions in lua/hunk/api/init.lua so users can call require("hunk.api").actions.toggle_lines(...) etc.
- Replaces the CONTEXT global with a first-class session object (hunk.Session) that is created per start() call and returned to the caller. All functions now receive session as an explicit parameter.
- Re-implements existing keybindings in init.lua through api.actions.* rather than private locals.
- Adds 9 new hooks to hunk.Config.hooks with LuaLS annotations: on_file_opened, on_file_previewed, on_file_toggled, on_line_toggled, on_hunk_toggled, on_hunk_navigated, on_focus_changed, on_before_accept, on_before_quit.
- Wires hook calls into tree.lua, file.lua, and actions.lua at the appropriate lifecycle points.
- Makes file.lua import only the sub-modules it needs (signs, fs) instead of the full api bundle.

No user-visible keybinding behavior changes. The default hooks are all no-ops, preserving existing semantics.